### PR TITLE
Replace UpdateTime registration from BreakPoint on pwd to prompt injection

### DIFF
--- a/Jump.Location/CommandController.cs
+++ b/Jump.Location/CommandController.cs
@@ -52,7 +52,7 @@ namespace Jump.Location
             if (waitPeriod != null)
                 waitPeriod.CloseAndUpdate();
 
-            IRecord record = database.GetByFullName(fullName);
+            var record = database.GetByFullName(fullName);
             waitPeriod = new DirectoryWaitPeriod(record, DateTime.Now);
             Save();
         }

--- a/Jump.Location/JumpLocationCommand.cs
+++ b/Jump.Location/JumpLocationCommand.cs
@@ -39,8 +39,6 @@ namespace Jump.Location
         [Parameter(ParameterSetName = "Query", HelpMessage = "Use pushd instead of cd to change directory. Same as `pushj`")]
         public SwitchParameter Push { get; set; }
 
-        private const string UpdateCommandString = @"[Jump.Location.JumpLocationCommand]::UpdateTime($($(Get-Item -Path $(Get-Location))).PSPath)";
-
         public static void UpdateTime(string location)
         {
             Controller.UpdateLocation(location);


### PR DESCRIPTION
This PR fixes #17.
It also address part of #15: now jump location track time only when promp function is called => only interactive user sessions. 
