### PR TITLE
Support ~ with the j command.

### DIFF
--- a/Jump.Location/SetJumpLocationCommand.cs
+++ b/Jump.Location/SetJumpLocationCommand.cs
@@ -89,9 +89,17 @@ namespace Jump.Location
                 destinationFound = true;
                 break;
             }
+
             if (!destinationFound)
             {
-                throw new LocationNotFoundException(String.Join(" ", Query));
+                // ask PowerShell to try to resolve the path (handling for things like "~")
+                var resolvedPath = GetUnresolvedProviderPathFromPSPath(Query.Last());
+
+                if (!Directory.Exists(resolvedPath))
+                {
+                    throw new LocationNotFoundException(String.Join(" ", Query));
+                }
+                ChangeDirectory(Query.Last());
             }
         }
 


### PR DESCRIPTION
Shortly after installing Jump-Location, I realized that I couldn't fully replace my `cd` usage with `j` because I often use `cd ~`. 

To resolve this, I've changed the j alias to instead be a function, so that I can call `Resolve-Path` if the path is an actual path instead of a shortcut. This way, commands like `j ~` will work.

One drawback to what I've currently got is that only the alias supports this - I'd have to change the actual Set-JumpLocation command otherwise. I didn't know if it was worth it for that or not.

I'm open to thoughts, criticisms, etc. Thanks so much!
