### PR TITLE
JumpStatus: scan now supports -Exclude.

### DIFF
--- a/Jump.Location/GetJumpStatusCommand.cs
+++ b/Jump.Location/GetJumpStatusCommand.cs
@@ -32,6 +32,10 @@ namespace Jump.Location
         [AllowEmptyString]
         public string Scan { get; set; }
 
+        [Parameter(HelpMessage = "Exclude directories and all subdirectories from scan.")]
+        [AllowEmptyCollection]
+        public string[] Exclude { get; set; }
+
         protected override void ProcessRecord()
         {
 
@@ -101,13 +105,23 @@ namespace Jump.Location
         private IEnumerable<string> GetChildFoldersRec(string path)
         {
             yield return path; 
-            foreach (string dir in Directory.GetDirectories(path))
+            foreach (string dir in Directory.GetDirectories(path).Where(ScanIncludesDirectory))
             {
                 foreach (string childDir in GetChildFoldersRec(dir))
                 {
                     yield return childDir;
                 }
             }
+        }
+
+        private bool ScanIncludesDirectory(string path) 
+        {
+            if (null == Exclude || Exclude.Length == 0) 
+            {
+                return true;
+            }
+
+            return !Exclude.Contains(new DirectoryInfo(path).Name, StringComparer.OrdinalIgnoreCase);
         }
 
         private void ProcessSearch(IEnumerable<IRecord> records)


### PR DESCRIPTION
Jumping around on my ramdisk got harder after a period of time, due to constantly changing and growing file system. There were a lot of pointless entries in the Jump-Location database, so I believe a kind of filtering would make sense.

I've added an -Exclude parameter, which defines the directories, which will be excluded.
For example: PS :\> jumpstat -Scan . -Exclude node_modules,jspm_packages
which will exclude every node_modules, jspm_packages and their subfolders from the scan. Note that subfolders exclusion differs from the Get-ChildItem's -Exclude behavior.

I'm using currently the following command to scan (.NET and web development area):
jumpstat -Scan . -Exclude packages,node_modules,jspm_packages,testresults,`$tf,.vs,.git,bin,obj

Please note, that I've added this only in combination with -Scan. I prefer to decide on my own, when to save, so I turned off the "autosave" functionality in my profile.