### PR TITLE
Added cmdlet and alias names to manifest to enable auto-loading of this module

### DIFF
--- a/Jump.Location/Jump.Location.psd1
+++ b/Jump.Location/Jump.Location.psd1
@@ -69,13 +69,19 @@ NestedModules = @()
 FunctionsToExport = '*'
 
 # Cmdlets to export from this module
-CmdletsToExport = '*'
+CmdletsToExport = @(
+        "Get-JumpStatus", 
+        "Set-JumpLocation"
+)
 
 # Variables to export from this module
 VariablesToExport = '*'
 
 # Aliases to export from this module
-AliasesToExport = '*'
+AliasesToExport = @(
+        "j",
+        "jumpstat"
+)
 
 # List of all modules packaged with this module
 ModuleList = @()


### PR DESCRIPTION
It is required that a module manifest file specifies the cmdlets and
aliases that the module will create once loaded in order for auto
loading of modules in powershell to load the module as soon as one of
its commandlets is called.

c.f. for example https://github.com/thoemmi/7Zip4Powershell/blob/master/7Zip4Powershell/7Zip4Powershell.psd1

This change will make Install.ps1 unnecessary and the users will not have to modify their $profile or call import-module explicitly.